### PR TITLE
Railway has bus icon instead of train

### DIFF
--- a/src/transport_thumbnail.js
+++ b/src/transport_thumbnail.js
@@ -19,6 +19,7 @@ class TransportThumbnail extends HTMLElement {
                 displayMode = '🚍';
                 break;
             case 'train':
+            case 'railway':
                 displayMode = '🚆';
                 break;
             case 'subway':


### PR DESCRIPTION
Relation railway has bus icon 🚍 instead of train 🚆.
See:
https://jungle-bus.github.io/unroll/route.html?line=12383180